### PR TITLE
Add FLX Training Videos

### DIFF
--- a/wiki/03-disciplines/01-lx/01-flx/index.md
+++ b/wiki/03-disciplines/01-lx/01-flx/index.md
@@ -6,6 +6,15 @@ resources:
   - name: FLX Manual
     url: https://www.zero88.com/manuals/zeros?filter=3
     author: Zero88
+  - name: FLX Training Videos (Introductory)
+    url: https://www.youtube.com/playlist?list=PLXZ_FRh4YdsV_xWV1WlKzgwcTt5h5KNsA
+    author: Zero88
+  - name: FLX Training Videos (Intermediate)
+    url: https://www.youtube.com/playlist?list=PLXZ_FRh4YdsXW-uQkLubuh5vm6RVU2a_d
+    author: Zero88
+  - name: FLX Training Videos (Advanced)
+    url: https://www.youtube.com/playlist?list=PLXZ_FRh4YdsW8J1hqDJGl-aTE1GnHQYJq
+    author: Zero88
 shortlinks:
   - flx
   - frogger


### PR DESCRIPTION
Add links to FLX training videos.

No idea how or why the last line is deleted and inserted. Probably something funny with the github web editor.